### PR TITLE
tcl/target: Use halt for CC3320SF targets

### DIFF
--- a/tcl/target/ti_cc3220sf.cfg
+++ b/tcl/target/ti_cc3220sf.cfg
@@ -26,6 +26,7 @@ flash bank $_FLASHNAME cc3220sf 0 0 0 0 $_TARGETNAME
 proc ocd_process_reset_inner { MODE } {
 
 	soft_reset_halt
+	halt
 
 	# Initialize MSP, PSP, and PC from vector table at flash 0x01000800
 	set boot [read_memory 0x01000800 32 2]


### PR DESCRIPTION
Got this solution from [sourceforge](https://sourceforge.net/p/openocd/tickets/360/)

Without this, the CC3220SF targets keep throwing ``Error: Could not write to register 'msp'``.