### PR TITLE
flash: wbz451/wbz351/pic32wm: Add custom OpenOCD flash driver and docs

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -6955,6 +6955,84 @@ USER PAGE: 0xAEECFF80FE9A9239
 
 @end deffn
 
+@anchor{wbz451}
+@deffn {Flash Driver} {wbz451}
+@cindex wbz451
+All members of the WBZ45x, PIC32CX_BZ2 microcontroller
+families from Microchip include internal flash and use ARM's Cortex-M4 core.
+
+This driver supports:
+@itemize
+@item Row programming (1024 bytes per row)
+@item Page erase (1024 bytes per row)
+@item Skipping @code{0xFF}-only regions for faster flashing
+@end itemize
+
+The driver is located at: @file{src/flash/nor/wbz451.c}.
+
+@example
+flash bank $_FLASHNAME wbz451 0x01000000 0x00100000 0 0 $_TARGETNAME
+@end example
+
+@deffn {Command} {wbz451 dsu_reset_deassert}
+This command releases internal reset held by DSU
+and prepares reset vector catch in case of reset halt.
+Command is used internally in event reset-deassert-post.
+@end deffn
+@end deffn
+
+@anchor{wbz351}
+@deffn {Flash Driver} {wbz351}
+@cindex wbz351
+All members of the WBZ35x, PIC32CX_BZ3 microcontroller
+families from Microchip include internal flash and use ARM's Cortex-M4 core.
+
+This driver supports:
+@itemize
+@item Row programming (1024 bytes per row)
+@item Page erase (1024 bytes per row)
+@item Skipping @code{0xFF}-only regions for faster flashing
+@end itemize
+
+The driver is located at: @file{src/flash/nor/wbz351.c}.
+
+@example
+flash bank $_FLASHNAME wbz351 0x01000000 0x00080000 0 0 $_TARGETNAME
+@end example
+
+@deffn {Command} {wbz351 dsu_reset_deassert}
+This command releases internal reset held by DSU
+and prepares reset vector catch in case of reset halt.
+Command is used internally in event reset-deassert-post.
+@end deffn
+@end deffn
+
+@anchor{pic32wm}
+@deffn {Flash Driver} {pic32wm}
+@cindex pic32wm
+All members of the WBZ65x, PIC32CX_BZ6 microcontroller
+families from Microchip include internal flash and use ARM's Cortex-M4 core.
+
+This driver supports:
+@itemize
+@item Row programming (1024 bytes per row)
+@item Page erase (1024 bytes per row)
+@item Skipping @code{0xFF}-only regions for faster flashing
+@end itemize
+
+The driver is located at: @file{src/flash/nor/pic32wm.c}.
+
+@example
+flash bank $_FLASHNAME pic32wm 0x01000000 0x00200000 0 0 $_TARGETNAME
+@end example
+
+@deffn {Command} {pic32wm dsu_reset_deassert}
+This command releases internal reset held by DSU
+and prepares reset vector catch in case of reset halt.
+Command is used internally in event reset-deassert-post.
+@end deffn
+@end deffn
+
 @deffn {Flash Driver} {atsamv}
 @cindex atsamv
 All members of the ATSAMV7x, ATSAMS70, and ATSAME70 families from

--- a/src/flash/nor/Makefile.am
+++ b/src/flash/nor/Makefile.am
@@ -12,7 +12,6 @@ NOR_DRIVERS = \
 	%D%/aduc702x.c \
 	%D%/aducm360.c \
 	%D%/ambiqmicro.c \
-	%D%/artery.c \
 	%D%/at91sam4.c \
 	%D%/at91sam4l.c \
 	%D%/at91samd.c \
@@ -83,10 +82,12 @@ NOR_DRIVERS = \
 	%D%/w600.c \
 	%D%/xcf.c \
 	%D%/xmc1xxx.c \
-	%D%/xmc4xxx.c
+	%D%/xmc4xxx.c \
+	%D%/wbz451.c \
+	%D%/wbz351.c \
+	%D%/pic32wm.c
 
 NORHEADERS = \
-	%D%/artery.h \
 	%D%/core.h \
 	%D%/cc3220sf.h \
 	%D%/bluenrg-x.h \

--- a/src/flash/nor/driver.h
+++ b/src/flash/nor/driver.h
@@ -313,5 +313,8 @@ extern const struct flash_driver w600_flash;
 extern const struct flash_driver xcf_flash;
 extern const struct flash_driver xmc1xxx_flash;
 extern const struct flash_driver xmc4xxx_flash;
+extern const struct flash_driver wbz451_flash;
+extern const struct flash_driver wbz351_flash;
+extern const struct flash_driver pic32wm_flash;
 
 #endif /* OPENOCD_FLASH_NOR_DRIVER_H */

--- a/src/flash/nor/drivers.c
+++ b/src/flash/nor/drivers.c
@@ -92,6 +92,9 @@ static const struct flash_driver * const flash_drivers[] = {
 	&xcf_flash,
 	&xmc1xxx_flash,
 	&xmc4xxx_flash,
+	&wbz451_flash,
+	&wbz351_flash,
+	&pic32wm_flash,
 };
 
 const struct flash_driver *flash_driver_find_by_name(const char *name)

--- a/src/flash/nor/pic32wm.c
+++ b/src/flash/nor/pic32wm.c
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/***************************************************************************
+ *   Copyright (C) 2025 by Microchip Technologies Inc                      *
+ *   Author: Dinesh Arasu - dinesh.arasu@microchip.com                     *
+ *                                                                         *
+ *   Description: Flash driver for PIC32WM_BZ6 Microchip Curiosity Board   *
+ ***************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "imp.h"
+#include "helper/binarybuffer.h"
+#include <helper/time_support.h>
+#include <jtag/jtag.h>
+#include <target/cortex_m.h>
+#include <stdbool.h>
+#include <string.h>
+#include <target/target_type.h>
+
+#define PIC32WM_FLASH        0x01000000
+#define PIC32WM_NVMDATA      0x44000640
+#define PIC32WM_NVMADDR      0x44000630
+#define PIC32WM_NVMCON       0x44000600
+#define PIC32WM_NVMKEY       0x44000620
+#define PIC32WM_NVMCONSET    0x44000608
+#define PIC32WM_NVMCONCLR    0x44000604
+#define PIC32WM_NVMSRCADDR   0x440006C0
+#define PIC32WM_PAC          0x40000000
+#define PIC32WM_NVM_PARAM    0x44000610
+#define PIC32WM_NVMLBWP      0x440006F0
+#define PIC32WM_NVMLBWP_UNLOCK_KEY       0x80000000
+
+#define NVMCON_NVMWREN          (1 << 14)
+#define NVMCON_NVMWR            (1 << 15)
+#define PIC32WM_NVM_ERR_MASK     0x3F00
+
+#define NVMCON_OP_WORD_PROG     0x4001
+#define NVMCON_OP_ROW_PROG      0x4003
+#define NVMCON_OP_PAGE_ERASE    0x4004
+#define NVMCON_OP_PBC           0x4007
+#define PIC32WM_NVMCON_OP_MASK   0x7FFF
+
+#define RAM_BUF_ADDR 0x20000000
+#define ROW_SIZE 1024
+#define PIC32WM_FLASH_END (0x01000000U + 1024U * 2048U)
+
+struct pic32wm_info {
+    struct target *target;
+    bool probed;
+    uint32_t page_size;
+    uint32_t num_pages;
+};
+
+static int pic32wm_unlock_flash(struct target *t) {
+    uint32_t status;
+    int res = target_read_u32(t, PIC32WM_PAC + 0x18, &status);
+    if (res != ERROR_OK)
+        return res;
+
+    if (status & (1 << 1)) {
+        LOG_INFO("PAC indicates NVMCTRL is locked. Attempting to unlock...");
+        res = target_write_u32(t, PIC32WM_PAC + 0x20, (1 << 1));
+        if (res != ERROR_OK)
+            return res;
+    }
+
+    res = target_read_u32(t, PIC32WM_PAC + 0x18, &status);
+
+    return res;
+}
+
+static int pic32wm_issue_nvmcmd(struct target *t, uint32_t flash_addr, uint16_t cmd, uint32_t src_addr)
+{
+    int res;
+
+    if (flash_addr < 0x00812000)    //Boot Flash, Device Config, Config Bits, OTP unlock sequence
+    {
+        res = target_write_u32(t, PIC32WM_NVMLBWP, PIC32WM_NVMLBWP_UNLOCK_KEY);
+        if (res != ERROR_OK) return res;
+    }
+    else{
+        // Step 1: Unlock NVMCTRL PAC (already does write to PAC/unlocks)
+        res = pic32wm_unlock_flash(t);
+        if (res != ERROR_OK)
+            return res;
+    }
+
+    // Step 2: Clear previous error flags (NVMERR, BORERR)
+    res = target_write_u32(t, PIC32WM_NVMCONCLR, PIC32WM_NVM_ERR_MASK);
+    if (res != ERROR_OK)
+        return res;
+    
+    // Row align
+    flash_addr &= ~(ROW_SIZE - 1);
+
+    // Step 3: Set NVMSRCADDR if command is ROW_PROG
+    if (cmd == NVMCON_OP_ROW_PROG) {
+        res = target_write_u32(t, PIC32WM_NVMSRCADDR, src_addr);
+        if (res != ERROR_OK)
+            return res;
+    }
+
+    // Step 4: Set NVMADDR with the destination Flash address
+    res = target_write_u32(t, PIC32WM_NVMADDR, flash_addr);
+    if (res != ERROR_OK)
+        return res;
+
+    // Step 5: Set WREN and operation code in NVMCON
+    res = target_write_u32(t, PIC32WM_NVMCON, NVMCON_NVMWREN | (cmd & PIC32WM_NVMCON_OP_MASK));
+    if (res != ERROR_OK)
+        return res;
+
+    // Step 6: NVMKEY unlock sequence
+    res = target_write_u32(t, PIC32WM_NVMKEY, 0x00000000);       // Reset
+    if (res != ERROR_OK) return res;
+    res = target_write_u32(t, PIC32WM_NVMKEY, 0xAA996655);       // Step 1
+    if (res != ERROR_OK) return res;
+    res = target_write_u32(t, PIC32WM_NVMKEY, 0x556699AA);       // Step 2
+    if (res != ERROR_OK) return res;
+
+    // Step 7: Set NVMWR bit to begin operation
+    res = target_write_u32(t, PIC32WM_NVMCONSET, NVMCON_NVMWR);
+    if (res != ERROR_OK)
+        return res;
+
+    // Step 8: Wait for NVMWR to clear (operation done)
+    uint32_t val;
+    int timeout = 10000;
+    do {
+        res = target_read_u32(t, PIC32WM_NVMCON, &val);
+        if (res != ERROR_OK)
+            return res;
+
+        if (!--timeout) {
+            LOG_ERROR("Timeout waiting for NVMWR clear (addr: 0x%08" PRIx32 ", cmd: 0x%X)",
+                    flash_addr, cmd);
+            return ERROR_FAIL;
+        }
+
+        alive_sleep(1);
+    } while (val & NVMCON_NVMWR);
+
+    // Step 9: Check error bits
+    if (val & PIC32WM_NVM_ERR_MASK) {
+        LOG_ERROR("NVM error detected (NVMCON=0x%08" PRIx32 ")", val);
+        return ERROR_FAIL;
+    }
+
+    // Step 10: Clear NVMWREN
+    return target_write_u32(t, PIC32WM_NVMCONCLR, NVMCON_NVMWREN);
+}
+
+static int pic32wm_probe(struct flash_bank *bank) {
+    struct pic32wm_info *info = bank->driver_priv;
+    if (!info) return ERROR_FAIL;
+    if (info->probed) return ERROR_OK;
+
+    uint32_t base = bank->base;
+    uint32_t param = 0;
+
+    target_read_u32(bank->target, PIC32WM_NVM_PARAM, &param);
+
+     if (base < 0x00010000) {
+        info->page_size = ROW_SIZE;     // 1KB
+        info->num_pages = 64;           // 512kb for slot 0/1 split up
+    } 
+    else if (bank->base >= 0x00800000 && bank->base < 0x00810000) {
+        info->page_size = ROW_SIZE;   // 1KB
+        info->num_pages = 64;     // 128KB info flash
+    }
+    else if (bank->base >= 0x00810000 && bank->base < 0x00811000) {
+        info->page_size = ROW_SIZE;   // 1KB
+        info->num_pages = 4;     // 128KB info flash
+    }
+    else if (bank->base >= 0x00811000 && bank->base < 0x00812000) {
+        info->page_size = ROW_SIZE;   // 1KB
+        info->num_pages = 4;     // 128KB info flash
+    }
+    else if (bank->base >= 0x01000000 && bank->base < 0x01200000) {
+        info->page_size = ROW_SIZE;   // 1KB
+        info->num_pages = 2048;     // 2MB info flash
+    }
+    else if (bank->base == 0xE000ED10){
+        info->page_size = ROW_SIZE;   // 1KB
+        info->num_pages = 1;     // 128KB info flash
+    }
+
+    bank->size = info->page_size * info->num_pages;
+    bank->num_sectors = info->num_pages;
+
+    /* Free existing memory to prevent leaks */
+    if (bank->sectors) {
+        free(bank->sectors);
+        bank->sectors = NULL;
+    }
+
+    bank->sectors = calloc(bank->num_sectors, sizeof(struct flash_sector));
+
+    if (!bank->sectors)
+        return ERROR_FAIL;
+
+    for (unsigned int i = 0; i < bank->num_sectors; ++i) {
+        bank->sectors[i].offset = i * info->page_size;
+        bank->sectors[i].size = info->page_size;
+        bank->sectors[i].is_protected = 0;
+    }
+
+    info->probed = true;
+    return ERROR_OK;
+}
+
+static int pic32wm_erase(struct flash_bank *bank, unsigned int first, unsigned int last) {
+    struct target *t = bank->target;
+    if (t->state != TARGET_HALTED) return ERROR_TARGET_NOT_HALTED;
+
+    for (unsigned int i = first; i <= last; i++) {
+        uint32_t addr = bank->base + i * ROW_SIZE;
+        int res = pic32wm_issue_nvmcmd(t, addr, NVMCON_OP_PAGE_ERASE, 0);
+        if (res != ERROR_OK) return res;
+    }
+    return ERROR_OK;
+}
+
+
+static int pic32wm_write(struct flash_bank *bank, const uint8_t *buf, uint32_t offset, uint32_t count)
+{
+    struct target *target = bank->target;
+    uint32_t addr = bank->base + offset;
+    const uint32_t end = addr + count;
+
+    if (target->state != TARGET_HALTED) {
+        LOG_ERROR("Target not halted");
+        return ERROR_TARGET_NOT_HALTED;
+    }
+
+
+    for (uint32_t row_addr = addr & ~(ROW_SIZE - 1); row_addr < end; row_addr += ROW_SIZE) {
+        uint8_t row_buf[ROW_SIZE];
+
+        // Read current row content from flash
+        int res = target_read_memory(target, row_addr, 4, ROW_SIZE / 4, row_buf);
+        if (res != ERROR_OK) {
+            LOG_ERROR("Failed to read flash row at 0x%08" PRIx32, row_addr);
+            return res;
+        }
+
+        for (uint32_t i = 0; i < ROW_SIZE; ++i) {
+            uint32_t abs_addr = row_addr + i;
+            if (abs_addr >= addr && abs_addr < end) {
+                row_buf[i] = buf[abs_addr - addr];
+            }
+        }
+        res = target_write_buffer(target, RAM_BUF_ADDR, ROW_SIZE, row_buf);
+        if (res != ERROR_OK) {
+            LOG_ERROR("Failed to write row buffer to RAM at 0x%08" PRIx32, RAM_BUF_ADDR);
+            return res;
+        }
+
+        res = pic32wm_issue_nvmcmd(target, row_addr, NVMCON_OP_ROW_PROG, RAM_BUF_ADDR);
+        if (res != ERROR_OK) {
+            LOG_ERROR("Failed to program row at 0x%08" PRIx32, row_addr);
+            return res;
+        }
+
+        alive_sleep(2);
+    }
+
+    LOG_INFO("PIC32WM: Write complete");
+    return ERROR_OK;
+}
+
+COMMAND_HANDLER(pic32wm_handle_dsu_reset_deassert)
+{
+    struct flash_bank *bank;
+    int result = get_flash_bank_by_name("pic32wm_flash", &bank);
+    if (result != ERROR_OK || !bank)
+        return ERROR_FAIL;
+    struct target *target = bank->target;
+
+    target_write_u8(target,0x44000001, 0x02); //Interrupt clear DSU -->STATUSA-->CRSTEXT
+
+    target_write_u32(target,0x44000100, 0x8000); //Set 15th bit 
+
+    target_write_u32(target, 0xE000ED0C, 0x05FA0004);
+
+    target_write_u32(target, 0xE000ED0C, 0x05fa0000);
+
+    alive_sleep(100);
+
+    return ERROR_OK;
+}
+
+FLASH_BANK_COMMAND_HANDLER(pic32wm_flash_bank_command) {
+    struct pic32wm_info *chip = calloc(1, sizeof(*chip));
+    if (!chip) return ERROR_FAIL;
+    chip->target = bank->target;
+    chip->probed = false;
+    bank->driver_priv = chip;
+    return ERROR_OK;
+}
+
+COMMAND_HANDLER(pic32wm_handle_erase_page_command) {
+    struct target *target = get_current_target(CMD_CTX);
+    if (!target || CMD_ARGC != 1) return ERROR_COMMAND_SYNTAX_ERROR;
+    uint32_t addr;
+    COMMAND_PARSE_NUMBER(u32, CMD_ARGV[0], addr);
+    return pic32wm_issue_nvmcmd(target, addr, NVMCON_OP_PAGE_ERASE, 0);
+}
+
+COMMAND_HANDLER(pic32wm_handle_write_word_command) {
+    struct target *target = get_current_target(CMD_CTX);
+    if (!target || CMD_ARGC != 2) return ERROR_COMMAND_SYNTAX_ERROR;
+    uint32_t addr, value;
+    COMMAND_PARSE_NUMBER(u32, CMD_ARGV[0], addr);
+    COMMAND_PARSE_NUMBER(u32, CMD_ARGV[1], value);
+    target_write_u32(target, PIC32WM_NVMDATA, value);
+    return pic32wm_issue_nvmcmd(target, addr, NVMCON_OP_WORD_PROG, 0);
+}
+
+static const struct command_registration pic32wm_exec_command_handlers[] = {
+    {
+        .name = "erase_page",
+        .handler = pic32wm_handle_erase_page_command,
+        .mode = COMMAND_EXEC,
+        .usage = "<address>",
+        .help = "Erase a flash page at the given address",
+    },
+    {
+        .name = "write_word",
+        .handler = pic32wm_handle_write_word_command,
+        .mode = COMMAND_EXEC,
+        .usage = "<address> <32bit_hex_value>",
+        .help = "Write a 32-bit word to flash at the given address",
+    },
+    {
+        .name = "dsu_reset_deassert",
+        .handler = pic32wm_handle_dsu_reset_deassert,
+        .mode = COMMAND_EXEC,
+        .usage = "<address> <32bit_hex_value>",
+        .help = "PIC32WM custom reset deassert sequence",
+    },
+
+    COMMAND_REGISTRATION_DONE
+};
+
+static const struct command_registration pic32wm_command_handlers[] = {
+    {
+        .name = "pic32wm",
+        .mode = COMMAND_ANY,
+        .help = "PIC32WM flash command group",
+        .usage = "",
+        .chain = pic32wm_exec_command_handlers,
+    },
+    COMMAND_REGISTRATION_DONE
+};
+
+const struct flash_driver pic32wm_flash = {
+    .name                = "pic32wm",
+    .commands            = pic32wm_command_handlers,
+    .flash_bank_command  = pic32wm_flash_bank_command,
+    .erase               = pic32wm_erase,
+    .protect             = NULL,
+    .write               = pic32wm_write,
+    .read                = default_flash_read,
+    .probe               = pic32wm_probe,
+    .auto_probe          = pic32wm_probe,
+    .erase_check         = default_flash_blank_check,
+    .protect_check       = NULL,
+    .free_driver_priv    = default_flash_free_driver_priv,
+};

--- a/src/flash/nor/wbz351.c
+++ b/src/flash/nor/wbz351.c
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/***************************************************************************
+ *   Copyright (C) 2025 by Microchip Technologies Inc                      *
+ *   Author: Dinesh Arasu - dinesh.arasu@microchip.com                     *
+ *                                                                         *
+ *   Description: Flash driver for WBZ351 Microchip Curiosity Board        *
+ ***************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "imp.h"
+#include "helper/binarybuffer.h"
+#include <helper/time_support.h>
+#include <jtag/jtag.h>
+#include <target/cortex_m.h>
+#include <stdbool.h>
+#include <string.h>
+#include <target/target_type.h>
+
+#define WBZ351_FLASH        0x01000000
+#define WBZ351_NVMDATA      0x44000640
+#define WBZ351_NVMADDR      0x44000630
+#define WBZ351_NVMCON       0x44000600
+#define WBZ351_NVMKEY       0x44000620
+#define WBZ351_NVMCONSET    0x44000608
+#define WBZ351_NVMCONCLR    0x44000604
+#define WBZ351_NVMSRCADDR   0x440006C0
+#define WBZ351_PAC          0x40000000
+#define WBZ351_NVM_PARAM    0x44000610
+#define WBZ351_NVMLBWP      0x440006F0
+#define WBZ351_NVMLBWP_UNLOCK_KEY       0x80000000
+
+#define NVMCON_NVMWREN          (1 << 14)
+#define NVMCON_NVMWR            (1 << 15)
+#define WBZ351_NVM_ERR_MASK     0x3F00
+
+#define NVMCON_OP_WORD_PROG     0x4001
+#define NVMCON_OP_ROW_PROG      0x4003
+#define NVMCON_OP_PAGE_ERASE    0x4004
+#define NVMCON_OP_PBC           0x4007
+#define WBZ351_NVMCON_OP_MASK   0x7FFF
+
+#define RAM_BUF_ADDR 0x20000000
+#define ROW_SIZE 1024
+#define WBZ351_FLASH_END (0x01000000U + 1024U * 512U)
+
+struct wbz351_info {
+    struct target *target;
+    bool probed;
+    uint32_t page_size;
+    uint32_t num_pages;
+};
+
+
+static int wbz351_unlock_flash(struct target *t) {
+    uint32_t status;
+    int res = target_read_u32(t, WBZ351_PAC + 0x18, &status);
+    if (res != ERROR_OK)
+        return res;
+
+    if (status & (1 << 1)) {
+        LOG_INFO("PAC indicates NVMCTRL is locked. Attempting to unlock...");
+        res = target_write_u32(t, WBZ351_PAC + 0x20, (1 << 1));
+        if (res != ERROR_OK)
+            return res;
+    }
+
+    res = target_read_u32(t, WBZ351_PAC + 0x18, &status);
+
+    return res;
+}
+
+static int wbz351_issue_nvmcmd(struct target *t, uint32_t flash_addr, uint16_t cmd, uint32_t src_addr)
+{
+    int res;
+
+    if(flash_addr < 0x00827000)  //boot flash unlock sequence
+    {
+        res = target_write_u32(t, WBZ351_NVMLBWP, WBZ351_NVMLBWP_UNLOCK_KEY);
+        if (res != ERROR_OK) return res;
+    }
+    else{
+        // Step 1: Unlock NVMCTRL PAC (already does write to PAC/unlocks)
+        res = wbz351_unlock_flash(t);
+        if (res != ERROR_OK)
+            return res;
+    }
+
+    // Step 2: Clear previous error flags (NVMERR, BORERR)
+    res = target_write_u32(t, WBZ351_NVMCONCLR, WBZ351_NVM_ERR_MASK);
+    if (res != ERROR_OK)
+        return res;
+    
+    // Row align
+    flash_addr &= ~(ROW_SIZE - 1);
+
+    // Step 3: Set NVMSRCADDR if command is ROW_PROG
+    if (cmd == NVMCON_OP_ROW_PROG) {
+        res = target_write_u32(t, WBZ351_NVMSRCADDR, src_addr);
+        if (res != ERROR_OK)
+            return res;
+    }
+
+    // Step 4: Set NVMADDR with the destination Flash address
+    res = target_write_u32(t, WBZ351_NVMADDR, flash_addr);
+    if (res != ERROR_OK)
+        return res;
+
+    // Step 5: Set WREN and operation code in NVMCON
+    res = target_write_u32(t, WBZ351_NVMCON, NVMCON_NVMWREN | (cmd & WBZ351_NVMCON_OP_MASK));
+    if (res != ERROR_OK)
+        return res;
+
+    // Step 6: NVMKEY unlock sequence
+    res = target_write_u32(t, WBZ351_NVMKEY, 0x00000000);       // Reset
+    if (res != ERROR_OK) return res;
+    res = target_write_u32(t, WBZ351_NVMKEY, 0xAA996655);       // Step 1
+    if (res != ERROR_OK) return res;
+    res = target_write_u32(t, WBZ351_NVMKEY, 0x556699AA);       // Step 2
+    if (res != ERROR_OK) return res;
+
+    // Step 7: Set NVMWR bit to begin operation
+    res = target_write_u32(t, WBZ351_NVMCONSET, NVMCON_NVMWR);
+    if (res != ERROR_OK)
+        return res;
+
+    // Step 8: Wait for NVMWR to clear (operation done)
+    uint32_t val;
+    int timeout = 10000;
+    do {
+        res = target_read_u32(t, WBZ351_NVMCON, &val);
+        if (res != ERROR_OK)
+            return res;
+
+        if (!--timeout) {
+            LOG_ERROR("Timeout waiting for NVMWR clear (addr: 0x%08" PRIx32 ", cmd: 0x%X)",
+                    flash_addr, cmd);
+            return ERROR_FAIL;
+        }
+
+        alive_sleep(1);
+    } while (val & NVMCON_NVMWR);
+
+    // Step 9: Check error bits
+    if (val & WBZ351_NVM_ERR_MASK) {
+        LOG_ERROR("NVM error detected (NVMCON=0x%08" PRIx32 ")", val);
+        return ERROR_FAIL;
+    }
+
+    // Step 10: Clear NVMWREN
+    return target_write_u32(t, WBZ351_NVMCONCLR, NVMCON_NVMWREN);
+}
+
+static int wbz351_probe(struct flash_bank *bank) {
+    struct wbz351_info *info = bank->driver_priv;
+    if (!info) return ERROR_FAIL;
+    if (info->probed) return ERROR_OK;
+
+    uint32_t base = bank->base;
+    uint32_t param = 0;
+
+    target_read_u32(bank->target, WBZ351_NVM_PARAM, &param);
+
+    if (base < 0x00010000) {
+        info->page_size = ROW_SIZE;
+        info->num_pages = 64;
+    } 
+    else if (bank->base >= 0x00800000 && base <0x00805000) {
+        info->page_size = ROW_SIZE;
+        info->num_pages = 20;
+    }
+    else if (bank->base >= 0x00805000 && bank->base < 0x00806000) {
+        info->page_size = ROW_SIZE;
+        info->num_pages = 4;
+    }
+    else if (bank->base >= 0x00806000 && bank->base < 0x00827000) {
+        info->page_size = ROW_SIZE;
+        info->num_pages = 132;
+    }
+    else if (bank->base >= 0x01000000 && bank->base < 0x01080000) {
+        info->page_size = ROW_SIZE;
+        info->num_pages = 512;
+    }
+    else if (bank->base == 0xE000ED10){
+        info->page_size = ROW_SIZE;
+        info->num_pages = 1;
+    }
+
+    bank->size = info->page_size * info->num_pages;
+    bank->num_sectors = info->num_pages;
+
+    /* Free existing memory to prevent leaks */
+    if (bank->sectors) {
+        free(bank->sectors);
+        bank->sectors = NULL;
+    }
+
+    bank->sectors = calloc(bank->num_sectors, sizeof(struct flash_sector));
+
+    if (!bank->sectors)
+        return ERROR_FAIL;
+
+    for (unsigned int i = 0; i < bank->num_sectors; ++i) {
+        bank->sectors[i].offset = i * info->page_size;
+        bank->sectors[i].size = info->page_size;
+        bank->sectors[i].is_protected = 0;
+    }
+
+    info->probed = true;
+    return ERROR_OK;
+}
+
+static int wbz351_erase(struct flash_bank *bank, unsigned int first, unsigned int last) {
+    struct target *t = bank->target;
+    if (t->state != TARGET_HALTED) return ERROR_TARGET_NOT_HALTED;
+
+    for (unsigned int i = first; i <= last; i++) {
+        uint32_t addr = bank->base + i * ROW_SIZE;
+        int res = wbz351_issue_nvmcmd(t, addr, NVMCON_OP_PAGE_ERASE, 0);
+        if (res != ERROR_OK) return res;
+    }
+    return ERROR_OK;
+}
+
+static int wbz351_write(struct flash_bank *bank, const uint8_t *buf, uint32_t offset, uint32_t count)
+{
+
+    struct target *target = bank->target;
+    uint32_t addr = bank->base + offset;
+    const uint32_t end = addr + count;
+
+    if (target->state != TARGET_HALTED) {
+        LOG_ERROR("Target not halted");
+        return ERROR_TARGET_NOT_HALTED;
+    }
+
+    for (uint32_t row_addr = addr & ~(ROW_SIZE - 1); row_addr < end; row_addr += ROW_SIZE) {
+        uint8_t row_buf[ROW_SIZE];
+
+        int res = target_read_memory(target, row_addr, 4, ROW_SIZE / 4, row_buf);
+        if (res != ERROR_OK)
+        {
+            LOG_ERROR("Failed to read flash row at 0x%08" PRIx32, row_addr);
+            return res;
+        }
+
+        for (uint32_t i = 0; i < ROW_SIZE; i++) {
+            uint32_t abs_addr = row_addr + i;
+            if (abs_addr >= addr && abs_addr < end) {
+                row_buf[i] = buf[abs_addr - addr];
+            }
+        }
+
+        res = target_write_buffer(target, RAM_BUF_ADDR, ROW_SIZE, row_buf);
+        if (res != ERROR_OK){
+            LOG_ERROR("Failed to write row buffer to RAM at 0x%08" PRIx32, RAM_BUF_ADDR);
+            return res;
+        }
+
+        res = wbz351_issue_nvmcmd(target, row_addr, NVMCON_OP_ROW_PROG, RAM_BUF_ADDR);
+        if (res != ERROR_OK) {
+            LOG_ERROR("Failed to program row at 0x%08" PRIx32, row_addr);
+            return res;
+        }
+
+        alive_sleep(2);
+    }
+
+    LOG_INFO("WBZ351: Write completed");
+
+    return ERROR_OK;
+}
+
+COMMAND_HANDLER(wbz351_handle_dsu_reset_deassert)
+{
+    struct flash_bank *bank;
+    int result = get_flash_bank_by_name("wbz351_flash", &bank);
+
+    if (result != ERROR_OK || !bank)
+        return ERROR_FAIL;
+
+    struct target *target = bank->target;
+
+    target_write_u8(target,0x44000001, 0x02);
+
+    target_write_u32(target,0x44000100, 0x8000);
+
+    target_write_u32(target, 0xE000ED0C, 0x05FA0004);
+
+    target_write_u32(target, 0xE000ED0C, 0x05fa0000);
+
+    alive_sleep(100);
+
+    return ERROR_OK;
+}
+
+FLASH_BANK_COMMAND_HANDLER(wbz351_flash_bank_command) {
+    struct wbz351_info *chip = calloc(1, sizeof(*chip));
+    if (!chip) return ERROR_FAIL;
+    chip->target = bank->target;
+    chip->probed = false;
+    bank->driver_priv = chip;
+    return ERROR_OK;
+}
+
+COMMAND_HANDLER(wbz351_handle_erase_page_command) {
+    struct target *target = get_current_target(CMD_CTX);
+    if (!target || CMD_ARGC != 1) return ERROR_COMMAND_SYNTAX_ERROR;
+    uint32_t addr;
+    COMMAND_PARSE_NUMBER(u32, CMD_ARGV[0], addr);
+    return wbz351_issue_nvmcmd(target, addr, NVMCON_OP_PAGE_ERASE, 0);
+}
+
+COMMAND_HANDLER(wbz351_handle_write_word_command) {
+    struct target *target = get_current_target(CMD_CTX);
+    if (!target || CMD_ARGC != 2) return ERROR_COMMAND_SYNTAX_ERROR;
+    uint32_t addr, value;
+    COMMAND_PARSE_NUMBER(u32, CMD_ARGV[0], addr);
+    COMMAND_PARSE_NUMBER(u32, CMD_ARGV[1], value);
+    target_write_u32(target, WBZ351_NVMDATA, value);
+    return wbz351_issue_nvmcmd(target, addr, NVMCON_OP_WORD_PROG, 0);
+}
+
+static const struct command_registration wbz351_exec_command_handlers[] = {
+    {
+        .name = "erase_page",
+        .handler = wbz351_handle_erase_page_command,
+        .mode = COMMAND_EXEC,
+        .usage = "<address>",
+        .help = "Erase a flash page at the given address",
+    },
+    {
+        .name = "write_word",
+        .handler = wbz351_handle_write_word_command,
+        .mode = COMMAND_EXEC,
+        .usage = "<address> <32bit_hex_value>",
+        .help = "Write a 32-bit word to flash at the given address",
+    },
+    {
+        .name = "dsu_reset_deassert",
+        .handler = wbz351_handle_dsu_reset_deassert,
+        .mode = COMMAND_EXEC,
+        .usage = "<address> <32bit_hex_value>",
+        .help = "WBZ351 custom reset deassert sequence",
+    },
+    COMMAND_REGISTRATION_DONE
+};
+
+static const struct command_registration wbz351_command_handlers[] = {
+    {
+        .name = "wbz351",
+        .mode = COMMAND_ANY,
+        .help = "WBZ351 flash command group",
+        .usage = "",
+        .chain = wbz351_exec_command_handlers,
+    },
+    COMMAND_REGISTRATION_DONE
+};
+
+const struct flash_driver wbz351_flash = {
+    .name                = "wbz351",
+    .commands            = wbz351_command_handlers,
+    .flash_bank_command  = wbz351_flash_bank_command,
+    .erase               = wbz351_erase,
+    .protect             = NULL,
+    .write               = wbz351_write,
+    .read                = default_flash_read,
+    .probe               = wbz351_probe,
+    .auto_probe          = wbz351_probe,
+    .erase_check         = default_flash_blank_check,
+    .protect_check       = NULL,
+    .free_driver_priv    = default_flash_free_driver_priv,
+};

--- a/src/flash/nor/wbz451.c
+++ b/src/flash/nor/wbz451.c
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/***************************************************************************
+ *   Copyright (C) 2025 by Microchip Technologies Inc                      *
+ *   Author: Dinesh Arasu - dinesh.arasu@microchip.com                     *
+ *                                                                         *
+ *   Description: Flash driver for WBZ451 Microchip Curiosity Board        *
+ ***************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "imp.h"
+#include "helper/binarybuffer.h"
+#include <helper/time_support.h>
+#include <jtag/jtag.h>
+#include <target/cortex_m.h>
+#include <stdbool.h>
+#include <string.h>
+#include <target/target_type.h>
+
+#define WBZ451_FLASH        0x01000000
+#define WBZ451_NVMDATA      0x44000640
+#define WBZ451_NVMADDR      0x44000630
+#define WBZ451_NVMCON       0x44000600
+#define WBZ451_NVMKEY       0x44000620
+#define WBZ451_NVMCONSET    0x44000608
+#define WBZ451_NVMCONCLR    0x44000604
+#define WBZ451_NVMSRCADDR   0x440006C0
+#define WBZ451_PAC          0x40000000
+#define WBZ451_NVM_PARAM    0x44000610
+#define WBZ451_NVMLBWP      0x440006F0
+#define WBZ451_NVMLBWP_UNLOCK_KEY       0x80000000
+
+#define NVMCON_NVMWREN          (1 << 14)
+#define NVMCON_NVMWR            (1 << 15)
+#define WBZ451_NVM_ERR_MASK     0x3F00
+
+#define NVMCON_OP_WORD_PROG     0x4001
+#define NVMCON_OP_ROW_PROG      0x4003
+#define NVMCON_OP_PAGE_ERASE    0x4004
+#define NVMCON_OP_PBC           0x4007
+#define WBZ451_NVMCON_OP_MASK   0x7FFF
+
+#define RAM_BUF_ADDR 0x20000000
+#define ROW_SIZE 1024                                                   // Row Size - 1KB
+#define WBZ451_FLASH_END (0x01000000U + 1024U * 1024U)                  // Flash Size - Flash End Address
+
+struct wbz451_info {
+    struct target *target;
+    bool probed;
+    uint32_t page_size;
+    uint32_t num_pages;
+};
+
+static int wbz451_unlock_flash(struct target *t) {
+    uint32_t status;
+    int res = target_read_u32(t, WBZ451_PAC + 0x18, &status);
+    if (res != ERROR_OK)
+        return res;
+
+    if (status & (1 << 1)) {
+        LOG_INFO("PAC indicates NVMCTRL is locked. Attempting to unlock...");
+        res = target_write_u32(t, WBZ451_PAC + 0x20, (1 << 1));
+        if (res != ERROR_OK)
+            return res;
+    }
+
+    res = target_read_u32(t, WBZ451_PAC + 0x18, &status);
+
+    return res;
+}
+
+static int wbz451_issue_nvmcmd(struct target *t, uint32_t flash_addr, uint16_t cmd, uint32_t src_addr)
+{
+    int res;
+
+    if(flash_addr < WBZ451_FLASH)  //Boot Flash, Device Config, Config Bits, OTP unlock sequence
+    {
+        res = target_write_u32(t, WBZ451_NVMLBWP, WBZ451_NVMLBWP_UNLOCK_KEY);
+        if (res != ERROR_OK) return res;
+    }
+    else{
+        // Step 1: Unlock NVMCTRL PAC (already does write to PAC/unlocks)
+        res = wbz451_unlock_flash(t);
+        if (res != ERROR_OK)
+            return res;
+    }
+
+    // Step 2: Clear previous error flags (NVMERR, BORERR)
+    res = target_write_u32(t, WBZ451_NVMCONCLR, WBZ451_NVM_ERR_MASK);
+    if (res != ERROR_OK)
+        return res;
+    
+    // Row alignment
+    flash_addr &= ~(ROW_SIZE - 1);
+
+    // Step 3: Set NVMSRCADDR if command is ROW_PROG
+    if (cmd == NVMCON_OP_ROW_PROG) {
+        res = target_write_u32(t, WBZ451_NVMSRCADDR, src_addr);
+        if (res != ERROR_OK)
+            return res;
+    }
+
+    // Step 4: Set NVMADDR with the destination Flash address
+    res = target_write_u32(t, WBZ451_NVMADDR, flash_addr);
+    if (res != ERROR_OK)
+        return res;
+
+    // Step 5: Set WREN and operation code in NVMCON
+    res = target_write_u32(t, WBZ451_NVMCON, NVMCON_NVMWREN | (cmd & WBZ451_NVMCON_OP_MASK));
+    if (res != ERROR_OK)
+        return res;
+
+    // Step 6: NVMKEY unlock sequence
+    res = target_write_u32(t, WBZ451_NVMKEY, 0x00000000);       // Reset
+    if (res != ERROR_OK) return res;
+    res = target_write_u32(t, WBZ451_NVMKEY, 0xAA996655);       // Step 1
+    if (res != ERROR_OK) return res;
+    res = target_write_u32(t, WBZ451_NVMKEY, 0x556699AA);       // Step 2
+    if (res != ERROR_OK) return res;
+
+    // Step 7: Set NVMWR bit to begin operation
+    res = target_write_u32(t, WBZ451_NVMCONSET, NVMCON_NVMWR);
+    if (res != ERROR_OK)
+        return res;
+
+    // Step 8: Wait for NVMWR to clear (operation done)
+    uint32_t val;
+    int timeout = 10000;
+    do {
+        res = target_read_u32(t, WBZ451_NVMCON, &val);
+        if (res != ERROR_OK)
+            return res;
+
+        if (!--timeout) {
+            LOG_ERROR("Timeout waiting for NVMWR clear (addr: 0x%08" PRIx32 ", cmd: 0x%X)",
+                    flash_addr, cmd);
+            return ERROR_FAIL;
+        }
+
+        alive_sleep(1);
+    } while (val & NVMCON_NVMWR);
+
+    // Step 9: Check error bits
+    if (val & WBZ451_NVM_ERR_MASK) {
+        LOG_ERROR("NVM error detected (NVMCON=0x%08" PRIx32 ")", val);
+        return ERROR_FAIL;
+    }
+
+    // Step 10: Clear NVMWREN
+    return target_write_u32(t, WBZ451_NVMCONCLR, NVMCON_NVMWREN);
+}
+
+static int wbz451_probe(struct flash_bank *bank) {
+    struct wbz451_info *info = bank->driver_priv;
+    if (!info) return ERROR_FAIL;
+    if (info->probed) return ERROR_OK;
+
+    uint32_t base = bank->base;
+    uint32_t param = 0;
+
+    target_read_u32(bank->target, WBZ451_NVM_PARAM, &param);
+
+    if (base < 0x00005000) {
+        info->page_size = ROW_SIZE;
+        info->num_pages = 20;                                           // 20 kB BootFlash
+    } 
+    else if (base >= 0x00005000 && base < 0x00006000) {
+        info->page_size = ROW_SIZE;
+        info->num_pages = 4;                                            // 4KB Device Config/Boot (Alias)
+    } 
+    else if (base >= 0x00006000 && base < 0x00007000) {
+        info->page_size = ROW_SIZE;
+        info->num_pages = 4;                                            // 4KB OTP Page Alias
+    } 
+    else if (base >= 0x00045000 && base < 0x00047000) {
+        info->page_size = ROW_SIZE;
+        info->num_pages = 8;                                            // 8KB ConfigBits
+    } 
+    else if (base >= 0x01000000 && base < 0x01100000) {
+        info->page_size = ROW_SIZE;
+        info->num_pages = 1024;                                         // 1MB flash memory
+    }
+    else if (bank->base == 0xE000ED10){
+        info->page_size = ROW_SIZE;
+        info->num_pages = 1;                                            
+    }
+
+    bank->size = info->page_size * info->num_pages;
+    bank->num_sectors = info->num_pages;
+
+    /* Free existing memory to prevent leaks */
+    if (bank->sectors) {
+        free(bank->sectors);
+        bank->sectors = NULL;
+    }
+
+    bank->sectors = calloc(bank->num_sectors, sizeof(struct flash_sector));
+
+    if (!bank->sectors)
+        return ERROR_FAIL;
+
+    // LOG_INFO("Bank Size 0x%32" PRIx32, bank->size);
+    for (unsigned int i = 0; i < bank->num_sectors; ++i) {
+        bank->sectors[i].offset = i * info->page_size;
+        bank->sectors[i].size = info->page_size;
+        bank->sectors[i].is_protected = 0;
+    }
+    info->probed = true;
+    return ERROR_OK;
+}
+
+static int wbz451_erase(struct flash_bank *bank, unsigned int first, unsigned int last) {
+    struct target *t = bank->target;
+    if (t->state != TARGET_HALTED) return ERROR_TARGET_NOT_HALTED;
+
+    for (unsigned int i = first; i <= last; i++) {
+        uint32_t addr = bank->base + i * ROW_SIZE;
+        int res = wbz451_issue_nvmcmd(t, addr, NVMCON_OP_PAGE_ERASE, 0);
+        if (res != ERROR_OK) return res;
+    }
+
+    return ERROR_OK;
+}
+
+static int wbz451_write(struct flash_bank *bank, const uint8_t *buf, uint32_t offset, uint32_t count)
+{
+    struct target *target = bank->target;
+    uint32_t addr = bank->base + offset;
+    const uint32_t end = addr + count;
+
+    if (target->state != TARGET_HALTED) {
+        LOG_ERROR("Target not halted");
+        return ERROR_TARGET_NOT_HALTED;
+    }
+
+    for (uint32_t row_addr = addr & ~(ROW_SIZE - 1); row_addr < end; row_addr += ROW_SIZE) {
+        uint8_t row_buf[ROW_SIZE];
+
+        // LOG_INFO("Reading row at 0x%08" PRIx32 " for modify", row_addr);
+
+        // Read current row content from flash
+        int res = target_read_memory(target, row_addr, 4, ROW_SIZE / 4, row_buf);
+        if (res != ERROR_OK) {
+            LOG_ERROR("Failed to read flash row at 0x%08" PRIx32, row_addr);
+            return res;
+        }
+
+        // Merge new data into row buffer
+        for (uint32_t i = 0; i < ROW_SIZE; ++i) {
+            uint32_t abs_addr = row_addr + i;
+            if (abs_addr >= addr && abs_addr < end) {
+                row_buf[i] = buf[abs_addr - addr];
+            }
+        }
+        // Write modified row buffer to RAM
+        // LOG_INFO("Writing row to RAM buffer at 0x%08" PRIx32, RAM_BUF_ADDR);
+        res = target_write_buffer(target, RAM_BUF_ADDR, ROW_SIZE, row_buf);
+        if (res != ERROR_OK) {
+            LOG_ERROR("Failed to write row buffer to RAM at 0x%08" PRIx32, RAM_BUF_ADDR);
+            return res;
+        }
+
+        // Program the flash row from RAM
+        // LOG_INFO("Programming row at 0x%08" PRIx32, row_addr);
+        res = wbz451_issue_nvmcmd(target, row_addr, NVMCON_OP_ROW_PROG, RAM_BUF_ADDR);
+        if (res != ERROR_OK) {
+            LOG_ERROR("Failed to program row at 0x%08" PRIx32, row_addr);
+            return res;
+        }
+
+        alive_sleep(2);
+    }
+
+    LOG_INFO("WBZ451: Write completed");
+
+    return ERROR_OK;
+}
+
+COMMAND_HANDLER(wbz451_handle_dsu_reset_deassert)
+{
+    struct flash_bank *bank;
+    int result = get_flash_bank_by_name("wbz451_flash", &bank);
+
+    if (result != ERROR_OK || !bank)
+        return ERROR_FAIL;
+
+    struct target *target = bank->target;
+
+    target_write_u8(target,0x44000001, 0x02);
+
+    target_write_u32(target,0x44000100, 0x8000);
+
+    target_write_u32(target, 0xE000ED0C, 0x05FA0004);
+
+    target_write_u32(target, 0xE000ED0C, 0x05fa0000);
+
+    alive_sleep(100);
+    
+    return ERROR_OK;
+}
+
+FLASH_BANK_COMMAND_HANDLER(wbz451_flash_bank_command) {
+    struct wbz451_info *chip = calloc(1, sizeof(*chip));
+    if (!chip) return ERROR_FAIL;
+    chip->target = bank->target;
+    chip->probed = false;
+    bank->driver_priv = chip;
+    return ERROR_OK;
+}
+
+COMMAND_HANDLER(wbz451_handle_erase_page_command) {
+    struct target *target = get_current_target(CMD_CTX);
+    if (!target || CMD_ARGC != 1) return ERROR_COMMAND_SYNTAX_ERROR;
+    uint32_t addr;
+    COMMAND_PARSE_NUMBER(u32, CMD_ARGV[0], addr);
+    return wbz451_issue_nvmcmd(target, addr, NVMCON_OP_PAGE_ERASE, 0);
+}
+
+COMMAND_HANDLER(wbz451_handle_write_word_command) {
+    struct target *target = get_current_target(CMD_CTX);
+    if (!target || CMD_ARGC != 2) return ERROR_COMMAND_SYNTAX_ERROR;
+    uint32_t addr, value;
+    COMMAND_PARSE_NUMBER(u32, CMD_ARGV[0], addr);
+    COMMAND_PARSE_NUMBER(u32, CMD_ARGV[1], value);
+    target_write_u32(target, WBZ451_NVMDATA, value);
+    return wbz451_issue_nvmcmd(target, addr, NVMCON_OP_WORD_PROG, 0);
+}
+
+static const struct command_registration wbz451_exec_command_handlers[] = {
+    {
+        .name = "erase_page",
+        .handler = wbz451_handle_erase_page_command,
+        .mode = COMMAND_EXEC,
+        .usage = "<address>",
+        .help = "Erase a flash page at the given address",
+    },
+    {
+        .name = "write_word",
+        .handler = wbz451_handle_write_word_command,
+        .mode = COMMAND_EXEC,
+        .usage = "<address> <32bit_hex_value>",
+        .help = "Write a 32-bit word to flash at the given address",
+    },
+    {
+        .name = "dsu_reset_deassert",
+        .handler = wbz451_handle_dsu_reset_deassert,
+        .mode = COMMAND_EXEC,
+        .usage = "<address> <32bit_hex_value>",
+        .help = "WBZ451 custom reset deassert sequence",
+    },
+    COMMAND_REGISTRATION_DONE
+};
+
+static const struct command_registration wbz451_command_handlers[] = {
+    {
+        .name = "wbz451",
+        .mode = COMMAND_ANY,
+        .help = "WBZ451 flash command group",
+        .usage = "",
+        .chain = wbz451_exec_command_handlers,
+    },
+    COMMAND_REGISTRATION_DONE
+};
+
+const struct flash_driver wbz451_flash = {
+    .name                = "wbz451",
+    .commands            = wbz451_command_handlers,
+    .flash_bank_command  = wbz451_flash_bank_command,
+    .erase               = wbz451_erase,
+    .protect             = NULL,
+    .write               = wbz451_write,
+    .read                = default_flash_read,
+    .probe               = wbz451_probe,
+    .auto_probe          = wbz451_probe,
+    .erase_check         = default_flash_blank_check,
+    .protect_check       = NULL,
+    .free_driver_priv    = default_flash_free_driver_priv,
+};

--- a/src/target/image.h
+++ b/src/target/image.h
@@ -25,7 +25,7 @@
 #endif
 
 #define IMAGE_MAX_ERROR_STRING		(256)
-#define IMAGE_MAX_SECTIONS			(512)
+#define IMAGE_MAX_SECTIONS			(2048)
 
 #define IMAGE_MEMORY_CACHE_SIZE		(2048)
 

--- a/tcl/board/microchip_pic32wm_bz6204_curiosity.cfg
+++ b/tcl/board/microchip_pic32wm_bz6204_curiosity.cfg
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+#
+# Microchip pic32wm_bz6 Curiosity Board.
+# https://www.microchip.com/en-us/development-tool/ea81w68a
+#
+
+source [find interface/cmsis-dap.cfg]
+
+set CHIPNAME pic32wm
+
+source [find target/pic32wm.cfg]
+
+reset_config srst_only

--- a/tcl/board/microchip_wbz351_curiosity.cfg
+++ b/tcl/board/microchip_wbz351_curiosity.cfg
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+#
+# Microchip WBZ351 Curiosity Board.
+# https://www.microchip.com/en-us/development-tool/EV19J06A
+#
+
+source [find interface/cmsis-dap.cfg]
+
+set CHIPNAME wbz351
+
+source [find target/wbz351.cfg]
+
+reset_config srst_only

--- a/tcl/board/microchip_wbz451_curiosity.cfg
+++ b/tcl/board/microchip_wbz451_curiosity.cfg
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+#
+# Microchip WBZ451 Curiosity Board.
+# https://www.microchip.com/en-us/development-tool/ev96b94a
+#
+
+source [find interface/cmsis-dap.cfg]
+
+set CHIPNAME wbz451
+
+source [find target/wbz451.cfg]
+
+reset_config srst_only

--- a/tcl/target/pic32wm.cfg
+++ b/tcl/target/pic32wm.cfg
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# OpenOCD Target Config for Microchip PIC32WM_BZ6
+# Author: Dinesh Arasu (dinesh.arasu@microchip.com)
+
+# --- Setup DAP and CPU ---
+source [find target/swj-dp.tcl]
+
+if { [info exists CHIPNAME] } {
+   set _CHIPNAME $CHIPNAME
+} else {
+   set _CHIPNAME pic32wm
+}
+
+if { [info exists ENDIAN] } {
+   set _ENDIAN $ENDIAN
+} else {
+   set _ENDIAN little
+}
+
+if { [info exists DAP_TAPID] } {
+   set _DAP_TAPID $DAP_TAPID
+} else {
+   set _DAP_TAPID 0x04D8810B
+}
+
+transport select swd
+
+swj_newdap $_CHIPNAME cpu -irlen 4 -expected-id $_DAP_TAPID
+dap create $_CHIPNAME.dap -chain-position $_CHIPNAME.cpu
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME cortex_m -endian $_ENDIAN -dap $_CHIPNAME.dap
+
+# --- Work Area in RAM ---
+$_TARGETNAME configure -work-area-phys 0x20000000 \
+                       -work-area-size 0x80000 \
+                       -work-area-backup 0
+
+# --- Reset Behavior ---
+$_TARGETNAME configure -event reset-deassert-post {
+        pic32wm dsu_reset_deassert
+}
+
+reset_config srst_only srst_nogate
+
+adapter speed 2000
+
+if {![using_hla]} {
+   # if srst is not fitted use SYSRESETREQ to
+   # perform a soft reset
+   cortex_m reset_config sysresetreq
+}
+
+# --- Flash Banks ---
+flash bank pic32wm_flash pic32wm 0x01000000 0x00200000 0 0 $_TARGETNAME
+
+flash bank pic32wm_Secure_boot pic32wm 0x00000000 0x10000 0 0 $_TARGETNAME
+
+flash bank pic32wm_boot pic32wm 0x00800000 0x10000 0 0 $_TARGETNAME
+
+flash bank pic32wm_device_config pic32wm 0x00810000 0x1000 0 0 $_TARGETNAME
+
+flash bank pic32wm_otp_config pic32wm 0x00811000 0x1000 0 0 $_TARGETNAME
+
+flash bank pic32wm_config_CM4F pic32wm 0xE000ed10 0x100 0 0 $_TARGETNAME

--- a/tcl/target/wbz351.cfg
+++ b/tcl/target/wbz351.cfg
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# OpenOCD Target Config for Microchip WBZ351
+# Author: Dinesh Arasu (dinesh.arasu@microchip.com)
+
+# --- Setup DAP and CPU ---
+source [find target/swj-dp.tcl]
+
+if { [info exists CHIPNAME] } {
+   set _CHIPNAME $CHIPNAME
+} else {
+   set _CHIPNAME wbz351
+}
+
+if { [info exists ENDIAN] } {
+   set _ENDIAN $ENDIAN
+} else {
+   set _ENDIAN little
+}
+
+if { [info exists DAP_TAPID] } {
+   set _DAP_TAPID $DAP_TAPID
+} else {
+   set _DAP_TAPID 0x04D8810B
+}
+
+transport select swd
+
+swj_newdap $_CHIPNAME cpu -irlen 4 -expected-id $_DAP_TAPID
+dap create $_CHIPNAME.dap -chain-position $_CHIPNAME.cpu
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME cortex_m -endian $_ENDIAN -dap $_CHIPNAME.dap
+
+# --- Work Area in RAM ---
+$_TARGETNAME configure -work-area-phys 0x20000000 \
+                       -work-area-size 0x18000 \
+                       -work-area-backup 0
+
+# --- Reset Behavior ---
+$_TARGETNAME configure -event reset-deassert-post {
+        wbz351 dsu_reset_deassert
+}
+
+reset_config srst_only srst_nogate
+
+adapter speed 2000
+
+if {![using_hla]} {
+   # if srst is not fitted use SYSRESETREQ to
+   # perform a soft reset
+   cortex_m reset_config sysresetreq
+}
+
+# --- Flash Banks ---
+flash bank wbz351_flash wbz351 0x01000000 0x00080000 0 0 $_TARGETNAME
+
+flash bank wbz351_Secure_boot wbz351 0x00000000 0x10000 0 0 $_TARGETNAME
+
+flash bank wbz351_boot wbz351 0x00800000 0x5000 0 0 $_TARGETNAME
+
+flash bank wbz351_device_config wbz351 0x00805000 0x1000 0 0 $_TARGETNAME
+
+flash bank wbz351_otp_config wbz351 0x00806000 0x21000 0 0 $_TARGETNAME
+
+flash bank wbz351_config_CM4F wbz351 0xE000ed10 0x100 0 0 $_TARGETNAME
+

--- a/tcl/target/wbz451.cfg
+++ b/tcl/target/wbz451.cfg
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# OpenOCD Target Config for Microchip WBZ451
+# Author: Dinesh Arasu (dinesh.arasu@microchip.com)
+
+# --- Setup DAP and CPU ---
+source [find target/swj-dp.tcl]
+
+if { [info exists CHIPNAME] } {
+   set _CHIPNAME $CHIPNAME
+} else {
+   set _CHIPNAME wbz451
+}
+
+if { [info exists ENDIAN] } {
+   set _ENDIAN $ENDIAN
+} else {
+   set _ENDIAN little
+}
+
+if { [info exists DAP_TAPID] } {
+   set _DAP_TAPID $DAP_TAPID
+} else {
+   set _DAP_TAPID 0x04D8810B
+}
+
+transport select swd
+
+swj_newdap $_CHIPNAME cpu -irlen 4 -expected-id $_DAP_TAPID
+dap create $_CHIPNAME.dap -chain-position $_CHIPNAME.cpu
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME cortex_m -endian $_ENDIAN -dap $_CHIPNAME.dap
+
+# --- Work Area in RAM ---
+$_TARGETNAME configure -work-area-phys 0x20000000 \
+                       -work-area-size 0x20000 \
+                       -work-area-backup 0
+
+# --- Reset Behavior ---
+$_TARGETNAME configure -event reset-deassert-post {
+        wbz451 dsu_reset_deassert
+}
+
+reset_config srst_only srst_nogate
+
+adapter speed 2000
+
+if {![using_hla]} {
+   cortex_m reset_config sysresetreq
+}
+
+# --- Flash Banks ---
+flash bank wbz451_flash wbz451 0x01000000 0x00100000 0 0 $_TARGETNAME
+
+flash bank wbz451_boot wbz451 0x00000000 0x5000 0 0 $_TARGETNAME
+
+flash bank wbz451_device_config wbz451 0x00005000 0x1000 0 0 $_TARGETNAME
+
+flash bank wbz451_otp wbz451 0x00006000 0x1000 0 0 $_TARGETNAME
+
+flash bank wbz451_configbits wbz451 0x00045000 0x2000 0 0 $_TARGETNAME
+
+flash bank wbz451_config_CM4F wbz451 0xE000ed10 0x100 0 0 $_TARGETNAME


### PR DESCRIPTION
This PR adds support for the Microchip WBZ451/WBZ351/PIC32WM device in OpenOCD, including a new flash driver and target configuration file.

Features
Added wbz451.c/wbz351.c/pic32wm.c OpenOCD flash driver.
Added target/wbz451.cfg/wbz351.cfg/pic32wm.cfg  for target initialization.
Implemented row-based flash programming using NVMCON.
Added page erase commands.
Added multi-bank flash handling support.

Testing
Verified flashing .bin, .hex, and .elf files.
Tested with WBZ451 Curiosity board.
Compared results with MPLAB IPE programming.
Successfully debugged using GDB.